### PR TITLE
adding an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
-#Immutable Patch
+Immutable Patch
+====
 
 Apply RFC 6902 style patches to Immutable.JS data structures, such as `Maps`, `Lists`, and `Sets`.
+
+### Getting Started
+
+You may get the module via npm:
+
+```
+npm install immutablepatch
+```
+
+And apply JSON patches to an immutable JSON object:
+
+```js
+var Immutable = require('immutable');
+var patch = require('immutablepatch');
+
+var list = Immutable.fromJS([1, 2, [3, 4]]);
+var ops = Immutable.fromJS([
+  {op: 'replace', path: '/2/1', value: 10}
+]);
+
+var result = patch(list, ops);
+// var expected = Immutable.fromJS([1, 2, [3, 10]]);
+```
+
+You will probably need [`immutablediff`](https://github.com/intelie/immutable-js-diff) to generate diff operations.


### PR DESCRIPTION
I'm not good at English, but hopefully it will fix https://github.com/intelie/immutable-js-patch/issues/1

Preview here https://github.com/jiyinyiyong/immutable-js-patch/tree/improve-docs#immutable-patch

I quite wonder why these two packages a named `immutable-diff` and `immutable-patch`, which would be  much easier to be found?
https://www.npmjs.com/package/immutable-diff
https://www.npmjs.com/package/immutable-patch
