### PR TITLE
Handle top-level "replace" operation correctly

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -96,7 +96,7 @@ var anyPatch = function(any, pathArray, op, value) {
   }
 };
 
-var eachPatch = function(value, patches) {
+var eachPatchInternal = function(value, patches) {
   while (patches.size) {
     var firstPatch = patches.get(0);
     var patches = patches.slice(1);
@@ -104,6 +104,16 @@ var eachPatch = function(value, patches) {
     value = anyPatch(value, pathArray, firstPatch.get('op'), firstPatch.get('value'));
   }
   return value;
+};
+
+var eachPatch = function(value, patches) {
+  if (patches.size === 1) {
+    var onlyPatch = patches.get(0);
+    if (onlyPatch.get('op') === 'replace' && onlyPatch.get('path') === '/') {
+      return onlyPatch.get('value');
+    }
+  }
+  return eachPatchInternal(value, patches);
 };
 
 module.exports = eachPatch;


### PR DESCRIPTION
Prior to this change a patch list of the following shape:

```js
[
  {
    op: "replace"
    path: "/",
    value: anyValue
  }
]
```

would result in the original value being returned instead of the `replace` operation being honored.

Fixes #10