### PR TITLE
ES6 Module Export

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -107,3 +107,4 @@ var eachPatch = function(value, patches) {
 };
 
 module.exports = eachPatch;
+module.exports.default = eachPatch;


### PR DESCRIPTION
Hi, I've just added `module.exports.default` to `patch.js`. This allows you to use the es6 syntax to import this module on node. See the discussion [here](https://github.com/esnext/es6-module-transpiler/issues/85).