### PR TITLE
Workaround for rollup bug

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -116,5 +116,5 @@ var eachPatch = function(value, patches) {
   return eachPatchInternal(value, patches);
 };
 
+eachPatch.default = eachPatch;
 module.exports = eachPatch;
-module.exports.default = eachPatch;


### PR DESCRIPTION
Hi, the last PR I submitted (#12) causes rollup to fail when processing `patch.js`. This is due to [a bug in the commonjs rollup plugin](https://github.com/rollup/rollup-plugin-commonjs/issues/158). This PR just reshuffles a few lines, which stops rollup complaining.