### PR TITLE
Append items to end of List, when path ends with `-` 

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -49,6 +49,10 @@ var sequencePatch = function(sequence, firstPath, restPath, op, value) {
         var baseValue = (restPath[0].match(/^\d+$/)) ? Immutable.List() : Immutable.Map();
         return sequence.set(firstPath, anyPatch(baseValue, restPath, op, value));
       } else {
+        // special case, add to the end
+        if (firstPath === '-') {
+          return sequence.splice(sequence.size, 0, value);
+        }
         // special case, return the value
         return sequence.splice(firstPath, 0, value);
       }

--- a/tests/sequencePatch.test.js
+++ b/tests/sequencePatch.test.js
@@ -52,6 +52,17 @@ describe('Indexed sequence patch', function() {
     assert.ok(Immutable.is(result, expected));
   });
 
+  it('adds value to end', function () {
+    var list = Immutable.List([1, 2, 3]);
+    var ops = Immutable.fromJS([
+      {op: 'add', path: '/-', value: 4}
+    ]);
+
+    var result = patch(list, ops);
+    var expected = Immutable.List([1,2,3,4]);
+    assert.ok(Immutable.is(result, expected));
+  });
+
   it('replaces old values', function () {
     var list = Immutable.List([1,2,3]);
     var ops = Immutable.fromJS([
@@ -88,6 +99,17 @@ describe('Indexed sequence patch', function() {
       var result = patch(list, ops);
       var expected = Immutable.fromJS([1,2,3,[4,5,6]]);
 
+      assert.ok(Immutable.is(result, expected));
+    });
+
+    it('adds value to nested seq end', function () {
+      var list = Immutable.fromJS([1, 2, 3, [4, 5]]);
+      var ops = Immutable.fromJS([
+        {op: 'add', path: '/3/-', value: 6}
+      ]);
+
+      var result = patch(list, ops);
+      var expected = Immutable.fromJS([1,2,3,[4,5,6]]);
       assert.ok(Immutable.is(result, expected));
     });
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6902#section-4.1
>       An element to add to an existing array - whereupon the supplied
>       value is added to the array at the indicated location.  Any
>       elements at or above the specified index are shifted one position
>       to the right.  The specified index MUST NOT be greater than the
>       number of elements in the array.  If the "-" character is used to
>       index the end of the array (see [RFC6901]), this has the effect of
>       appending the value to the array.