### PR TITLE
Add immutable to peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "immutablediff": "^0.3.2",
     "jscheck": "^0.2.0"
   },
-  "dependencies": {
-    "immutable": "^3.2.1"
+  "peerDependencies": {
+    "immutable": "*"
   }
 }


### PR DESCRIPTION
- it ensures that the original Immutable version of the project using this library is used rather
We found this change necessary to solve this issue
rt2zz/redux-persist-transform-immutable#22

Since this library deals with data immutable data structures build outside the library it must accept Immutable as a peerDependency.